### PR TITLE
Create custom 404 page that works with GH Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "svelte-kit dev --host",
-    "build": "rm -rf build && svelte-kit build && touch build/.nojekyll",
+    "build": "rm -rf build && svelte-kit build && touch build/.nojekyll && mv build/404/index.html build/404.html",
     "deploy": "npm run build && npx gh-pages -d build -t true",
     "preview": "svelte-kit preview",
     "lint": "prettier --ignore-path .gitignore  --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",

--- a/src/routes/404@waves.svelte
+++ b/src/routes/404@waves.svelte
@@ -1,0 +1,44 @@
+<script>
+	import Error from '$lib/svg/error.svelte';
+</script>
+
+<div class="error-page">
+	<div class="container">
+		<h1>Oh no!</h1>
+		<div class="svg-wrapper">
+			<Error />
+		</div>
+		<p>It seems like coffee was spilled all over this page, and now it can't be displayed.</p>
+		<a class="button secondary" href="/">Start over</a>
+	</div>
+</div>
+
+<style lang="scss">
+	.error-page {
+		background: var(--page-background-color);
+    position: relative;
+	}
+	.container {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;		
+		min-height: 60vh;
+		text-align: center;
+
+		.svg-wrapper {
+			width: 300px;
+			margin-top: -60px;
+			margin-bottom: -30px;
+
+			:global(svg) {
+				filter: drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.1));
+			}
+		}
+
+		.button {
+			margin-top: 30px;
+			width: fit-content;
+		}
+	}
+</style>


### PR DESCRIPTION
Closes #13 .

Cloned the __error.svelte and used the build script to manually add it to the root of the generated folder as 404.html. This way, GitHub Pages displayed that file instead of its generic one.