### PR TITLE
Fix: accent colors for archive pages do not get applied on page refresh on dark mode

### DIFF
--- a/src/layouts/CoolLinksArchiveLayout.astro
+++ b/src/layouts/CoolLinksArchiveLayout.astro
@@ -82,6 +82,29 @@ allTags?.forEach((tag) => {
   @use '/src/styles/breakpoints';
   @use '/src/styles/typography';
 
+  :root {
+    &:has(.l-cool-links-archive) {
+      --theme--color-accent: var(--theme--color-cool-link);
+      --theme--color-accent-rgb: var(--theme--color-cool-link-rgb);
+      --theme--color-accent-contrast: var(--theme--color-cool-link-contrast);
+      --theme--color-accent-shade: var(--theme--color-cool-link-shade);
+      --theme--color-accent-tint: var(--theme--color-cool-link-tint);
+      --theme--color-accent-glow: var(--theme--color-cool-link-glow);
+    }
+
+    &[data-theme='dark'],
+    &[data-theme='auto'] {
+      &:has(.l-cool-links-archive) {
+        --theme--color-accent: var(--theme--color-cool-link);
+        --theme--color-accent-rgb: var(--theme--color-cool-link-rgb);
+        --theme--color-accent-contrast: var(--theme--color-cool-link-contrast);
+        --theme--color-accent-shade: var(--theme--color-cool-link-shade);
+        --theme--color-accent-tint: var(--theme--color-cool-link-tint);
+        --theme--color-accent-glow: var(--theme--color-cool-link-glow);
+      }
+    }
+  }
+
   :root:has(.l-cool-links-archive) {
     --theme--color-accent: var(--theme--color-cool-link);
     --theme--color-accent-rgb: var(--theme--color-cool-link-rgb);

--- a/src/layouts/CoolLinksArchiveLayout.astro
+++ b/src/layouts/CoolLinksArchiveLayout.astro
@@ -105,15 +105,6 @@ allTags?.forEach((tag) => {
     }
   }
 
-  :root:has(.l-cool-links-archive) {
-    --theme--color-accent: var(--theme--color-cool-link);
-    --theme--color-accent-rgb: var(--theme--color-cool-link-rgb);
-    --theme--color-accent-contrast: var(--theme--color-cool-link-contrast);
-    --theme--color-accent-shade: var(--theme--color-cool-link-shade);
-    --theme--color-accent-tint: var(--theme--color-cool-link-tint);
-    --theme--color-accent-glow: var(--theme--color-cool-link-glow);
-  }
-
   .l-cool-links-archive {
     &__container {
       display: flex;

--- a/src/layouts/PhotographyArchiveLayout.astro
+++ b/src/layouts/PhotographyArchiveLayout.astro
@@ -58,13 +58,27 @@ const paginationBaseUrl = '/photography';
 <style lang='scss'>
   @use '/src/styles/breakpoints';
 
-  :root:has(.l-photography-archive) {
-    --theme--color-accent: var(--theme--color-photography);
-    --theme--color-accent-rgb: var(--theme--color-photography-rgb);
-    --theme--color-accent-contrast: var(--theme--color-photography-contrast);
-    --theme--color-accent-shade: var(--theme--color-photography-shade);
-    --theme--color-accent-tint: var(--theme--color-photography-tint);
-    --theme--color-accent-glow: var(--theme--color-photography-glow);
+  :root {
+    &:has(.l-photography-archive) {
+      --theme--color-accent: var(--theme--color-photography);
+      --theme--color-accent-rgb: var(--theme--color-photography-rgb);
+      --theme--color-accent-contrast: var(--theme--color-photography-contrast);
+      --theme--color-accent-shade: var(--theme--color-photography-shade);
+      --theme--color-accent-tint: var(--theme--color-photography-tint);
+      --theme--color-accent-glow: var(--theme--color-photography-glow);
+    }
+
+    &[data-theme='dark'],
+    &[data-theme='auto'] {
+      &:has(.l-photography-archive) {
+        --theme--color-accent: var(--theme--color-photography);
+        --theme--color-accent-rgb: var(--theme--color-photography-rgb);
+        --theme--color-accent-contrast: var(--theme--color-photography-contrast);
+        --theme--color-accent-shade: var(--theme--color-photography-shade);
+        --theme--color-accent-tint: var(--theme--color-photography-tint);
+        --theme--color-accent-glow: var(--theme--color-photography-glow);
+      }
+    }
   }
 
   .l-photography-archive {

--- a/src/layouts/QuickReviewsArchiveLayout.astro
+++ b/src/layouts/QuickReviewsArchiveLayout.astro
@@ -129,13 +129,27 @@ if (currentRating) paginationBaseUrl += `/rating/${currentRating.toLowerCase()}`
   @use '/src/styles/breakpoints';
   @use '/src/styles/typography';
 
-  :root:has(.l-quick-reviews-archive) {
-    --theme--color-accent: var(--theme--color-quick-review);
-    --theme--color-accent-rgb: var(--theme--color-quick-review-rgb);
-    --theme--color-accent-contrast: var(--theme--color-quick-review-contrast);
-    --theme--color-accent-shade: var(--theme--color-quick-review-shade);
-    --theme--color-accent-tint: var(--theme--color-quick-review-tint);
-    --theme--color-accent-glow: var(--theme--color-quick-review-glow);
+  :root {
+    &:has(.l-quick-reviews-archive) {
+      --theme--color-accent: var(--theme--color-quick-review);
+      --theme--color-accent-rgb: var(--theme--color-quick-review-rgb);
+      --theme--color-accent-contrast: var(--theme--color-quick-review-contrast);
+      --theme--color-accent-shade: var(--theme--color-quick-review-shade);
+      --theme--color-accent-tint: var(--theme--color-quick-review-tint);
+      --theme--color-accent-glow: var(--theme--color-quick-review-glow);
+    }
+
+    &[data-theme='dark'],
+    &[data-theme='auto'] {
+      &:has(.l-quick-reviews-archive) {
+        --theme--color-accent: var(--theme--color-quick-review);
+        --theme--color-accent-rgb: var(--theme--color-quick-review-rgb);
+        --theme--color-accent-contrast: var(--theme--color-quick-review-contrast);
+        --theme--color-accent-shade: var(--theme--color-quick-review-shade);
+        --theme--color-accent-tint: var(--theme--color-quick-review-tint);
+        --theme--color-accent-glow: var(--theme--color-quick-review-glow);
+      }
+    }
   }
 
   .l-quick-reviews-archive {


### PR DESCRIPTION
Needed to add some more specificity to the selectors, as the dark theme was overriding the accent color